### PR TITLE
Update Defold GameConfig.cfg to work with latest Trenchbroom version

### DIFF
--- a/trenchfold/games/Defold/GameConfig.cfg
+++ b/trenchfold/games/Defold/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 4,
+    "version": 8,
     "name": "Defold",
     "icon": "defold.png",
     "fileformats": [
@@ -10,9 +10,8 @@
         "packageformat": { "extension": "zip", "format": "zip" }
     },
     "textures": {
-        "package": { "type": "directory", "root": "textures" },
-        "format": { "extensions": ["jpg", "jpeg", "tga", "png"], "format": "image" },
-        "attribute": "_tb_textures"
+        "root": "textures",
+        "extensions": ["jpg", "jpeg", "tga", "png"]
     },
     "entities": {
         "definitions": [ "Defold.fgd" ],


### PR DESCRIPTION
Latest version of Trenchbroom (2024.1 RC2) disallows config files of version 6 and lower, Trenchbroom on latest version will no longer create new projects with config file included in defold-trenchfold. Solved by updating config file to version 8 specifications.

See:
https://github.com/TrenchBroom/TrenchBroom/releases
https://trenchbroom.github.io/manual/latest/#game_configuration_files